### PR TITLE
Structured response for getImageMetadata

### DIFF
--- a/src/main/java/au/gov/ga/hydroid/dto/ImageAnnotation.java
+++ b/src/main/java/au/gov/ga/hydroid/dto/ImageAnnotation.java
@@ -1,0 +1,44 @@
+package au.gov.ga.hydroid.dto;
+
+/**
+ * Created by u24529 on 16/03/2016.
+ */
+public class ImageAnnotation {
+
+   private String description;
+   private float score;
+
+   public ImageAnnotation(String description, float score) {
+      this.description = description;
+      this.score = score;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public float getScore() {
+      return score;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ImageAnnotation that = (ImageAnnotation) o;
+
+      if (Float.compare(that.score, score) != 0) return false;
+      if (description != null ? !description.equals(that.description) : that.description != null) return false;
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = description != null ? description.hashCode() : 0;
+      result = 31 * result + (score != +0.0f ? Float.floatToIntBits(score) : 0);
+      return result;
+   }
+
+}

--- a/src/main/java/au/gov/ga/hydroid/dto/ImageMetadata.java
+++ b/src/main/java/au/gov/ga/hydroid/dto/ImageMetadata.java
@@ -1,0 +1,21 @@
+package au.gov.ga.hydroid.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by u24529 on 16/03/2016.
+ */
+public class ImageMetadata {
+
+   private List<ImageAnnotation> imageLabels;
+
+   public ImageMetadata() {
+      imageLabels = new ArrayList<>();
+   }
+
+   public List<ImageAnnotation> getImageLabels() {
+      return imageLabels;
+   }
+
+}

--- a/src/main/java/au/gov/ga/hydroid/service/ImageService.java
+++ b/src/main/java/au/gov/ga/hydroid/service/ImageService.java
@@ -1,5 +1,7 @@
 package au.gov.ga.hydroid.service;
 
+import au.gov.ga.hydroid.dto.ImageMetadata;
+
 import java.io.InputStream;
 
 /**
@@ -7,6 +9,6 @@ import java.io.InputStream;
  */
 public interface ImageService {
 
-   public String getImageMetadata(InputStream is);
+   public ImageMetadata getImageMetadata(InputStream is);
 
 }

--- a/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
@@ -1,6 +1,8 @@
 package au.gov.ga.hydroid.service.impl;
 
 import au.gov.ga.hydroid.HydroidConfiguration;
+import au.gov.ga.hydroid.dto.ImageAnnotation;
+import au.gov.ga.hydroid.dto.ImageMetadata;
 import au.gov.ga.hydroid.model.Document;
 import au.gov.ga.hydroid.model.DocumentType;
 import au.gov.ga.hydroid.model.EnhancementStatus;
@@ -312,6 +314,16 @@ public class EnhancerServiceImpl implements EnhancerService {
       }
    }
 
+   private String getImageMetadataAsString(InputStream s3FileContent) {
+      StringBuilder result = new StringBuilder();
+      ImageMetadata imageMetadata = imageService.getImageMetadata(s3FileContent);
+      for (ImageAnnotation imageLabel : imageMetadata.getImageLabels()) {
+         result.append(imageLabel.getDescription()).append(" (").append(imageLabel.getScore()).append(")\n");
+      }
+      result.setLength(result.length() - 1);
+      return result.toString();
+   }
+
    @Override
    public void enhanceDocuments() {
       enhanceCollection(DocumentType.DOCUMENT);
@@ -346,7 +358,7 @@ public class EnhancerServiceImpl implements EnhancerService {
             // The image metadata will be extracted and used for enhancement
             if (objectsForEnhancement.contains(object)) {
                s3FileContent = s3Client.getFile(object.getBucketName(), object.getKey());
-               imageMetadata = title + "\n" + imageService.getImageMetadata(s3FileContent);
+               imageMetadata = title + "\n" + getImageMetadataAsString(s3FileContent);
                // The cached imaged metadata will be used for enhancement
             } else {
                imageMetadata = documentService.readImageMetadata(origin);

--- a/src/main/java/au/gov/ga/hydroid/service/impl/GoogleVisionImageService.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/GoogleVisionImageService.java
@@ -1,6 +1,8 @@
 package au.gov.ga.hydroid.service.impl;
 
 import au.gov.ga.hydroid.HydroidConfiguration;
+import au.gov.ga.hydroid.dto.ImageAnnotation;
+import au.gov.ga.hydroid.dto.ImageMetadata;
 import au.gov.ga.hydroid.service.ImageService;
 import au.gov.ga.hydroid.utils.HydroidException;
 import com.google.api.client.googleapis.GoogleUtils;
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.GeneralSecurityException;
@@ -34,8 +37,14 @@ public class GoogleVisionImageService implements ImageService {
    @Autowired
    private HydroidConfiguration configuration;
 
+   private float round(float value, int newScale) {
+      BigDecimal bd = new BigDecimal(value);
+      bd = bd.setScale(newScale, BigDecimal.ROUND_HALF_UP);
+      return bd.floatValue();
+   }
+
    @Override
-   public String getImageMetadata(InputStream is) {
+   public ImageMetadata getImageMetadata(InputStream is) {
       if(is == null) {
          logger.debug("GoogleVisionImageService:getImageMetadata - input stream is null.");
          throw new HydroidException("input stream is null");
@@ -89,13 +98,15 @@ public class GoogleVisionImageService implements ImageService {
 
          response = annotateRequest.execute();
 
-         StringBuilder result = new StringBuilder();
+         ImageMetadata result = new ImageMetadata();
          for (AnnotateImageResponse imgRes : response.getResponses()) {
             for (EntityAnnotation entityAnnotation : imgRes.getLabelAnnotations()) {
-               result.append(entityAnnotation.getDescription()).append(",");
+               result.getImageLabels().add(
+                     new ImageAnnotation(entityAnnotation.getDescription(), round(entityAnnotation.getScore(), 2))
+               );
             }
          }
-         return result.substring(0, result.length() - 1);
+         return result;
       }
       catch (Throwable e) {
          throw new HydroidException(e);

--- a/src/main/java/au/gov/ga/hydroid/service/impl/ImageServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/ImageServiceImpl.java
@@ -1,5 +1,7 @@
 package au.gov.ga.hydroid.service.impl;
 
+import au.gov.ga.hydroid.dto.ImageAnnotation;
+import au.gov.ga.hydroid.dto.ImageMetadata;
 import au.gov.ga.hydroid.service.ImageService;
 import au.gov.ga.hydroid.utils.HydroidException;
 import org.apache.commons.lang.ArrayUtils;
@@ -24,8 +26,8 @@ public class ImageServiceImpl implements ImageService {
          "Windows XP Comment", "Windows XP Keywords", "Windows XP Subject", "Windows XP Title"};
 
    @Override
-   public String getImageMetadata(InputStream is) {
-      StringBuilder imageMetadata = new StringBuilder();
+   public ImageMetadata getImageMetadata(InputStream is) {
+      ImageMetadata imageMetadata = new ImageMetadata();
 
       try {
          Parser parser = new AutoDetectParser();
@@ -45,9 +47,10 @@ public class ImageServiceImpl implements ImageService {
                   if (propertyValue.indexOf(";") >= 0) {
                      propertyValue = propertyValue.replaceAll(";", "\n");
                   }
+                  ImageAnnotation imageLabel = new ImageAnnotation(propertyValue, 1);
                   // Only store unique values
-                  if (!imageMetadata.toString().toLowerCase().contains(propertyValue.toLowerCase())) {
-                     imageMetadata.append(propertyValue).append("\n");
+                  if (!imageMetadata.getImageLabels().contains(imageLabel)) {
+                     imageMetadata.getImageLabels().add(imageLabel);
                   }
                }
             }
@@ -57,7 +60,7 @@ public class ImageServiceImpl implements ImageService {
          throw new HydroidException(e);
       }
 
-      return imageMetadata.toString();
+      return imageMetadata;
    }
 
 }

--- a/src/test/java/au/gov/ga/hydroid/service/GoogleVisionTestIT.java
+++ b/src/test/java/au/gov/ga/hydroid/service/GoogleVisionTestIT.java
@@ -1,6 +1,8 @@
 package au.gov.ga.hydroid.service;
 
 import au.gov.ga.hydroid.HydroidApplication;
+import au.gov.ga.hydroid.dto.ImageAnnotation;
+import au.gov.ga.hydroid.dto.ImageMetadata;
 import au.gov.ga.hydroid.service.impl.GoogleVisionImageService;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,10 +27,11 @@ public class GoogleVisionTestIT {
 
    @Test
    public void testGoogleVisionApi() throws IOException, GeneralSecurityException {
+      Assert.assertNotNull("GOOGLE_APPLICATION_CREDENTIALS", System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
       InputStream imageStream = this.getClass().getResourceAsStream("/testfiles/hydroid-3.jpg");
-      String result = googleVisionImageService.getImageMetadata(imageStream);
+      ImageMetadata result = googleVisionImageService.getImageMetadata(imageStream);
       Assert.assertNotNull(result);
-      Assert.assertTrue(result.length() > 0);
+      Assert.assertTrue(result.getImageLabels().size() > 0);
    }
 
    @Test
@@ -42,10 +45,15 @@ public class GoogleVisionTestIT {
                String fileNameWithoutExt;
                if (Files.isRegularFile(filePath)) {
                   is = new FileInputStream(filePath.toFile());
-                  String result = googleVisionImageService.getImageMetadata(is);
+                  ImageMetadata result = googleVisionImageService.getImageMetadata(is);
                   fileNameWithoutExt = filePath.getFileName().toString().substring(0, filePath.getFileName().toString().length() - 4);
                   os = new FileOutputStream("src/test/resources/testfiles/google_vision/" + fileNameWithoutExt + ".txt");
-                  os.write(result.getBytes());
+                  BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os));
+                  for (ImageAnnotation imageLabel : result.getImageLabels()) {
+                     bw.write(imageLabel.getDescription() + "(" + imageLabel.getScore() + ")");
+                     bw.newLine();
+                  }
+                  bw.close();
                }
             } catch (Throwable e) {
                e.printStackTrace();

--- a/src/test/java/au/gov/ga/hydroid/service/ImageServiceTestIT.java
+++ b/src/test/java/au/gov/ga/hydroid/service/ImageServiceTestIT.java
@@ -1,6 +1,8 @@
 package au.gov.ga.hydroid.service;
 
 import au.gov.ga.hydroid.HydroidApplication;
+import au.gov.ga.hydroid.dto.ImageAnnotation;
+import au.gov.ga.hydroid.dto.ImageMetadata;
 import au.gov.ga.hydroid.service.impl.ImageServiceImpl;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,10 +28,16 @@ public class ImageServiceTestIT {
    @Test
    public void testGetImageMetadata() {
       InputStream imageStream = this.getClass().getResourceAsStream("/testfiles/hydroid-3.jpg");
-      String metadata = imageService.getImageMetadata(imageStream);
+      ImageMetadata metadata = imageService.getImageMetadata(imageStream);
+
+      StringBuilder actualMetadata = new StringBuilder();
+      for (ImageAnnotation imageLabel : metadata.getImageLabels()) {
+         actualMetadata.append(imageLabel.getDescription()).append("\n");
+      }
 
       String expectedMetadata = new StringBuilder("The Hydroid 3 Photo").append("\n")
             .append("Sub: The Hydroid 3 Photo").append("\n")
+            .append("Hydroid").append("\n")
             .append("PhotoMedia").append("\n")
             .append("Difficult to parse").append("\n")
             .append("Hydroid").append("\n")
@@ -39,7 +47,7 @@ public class ImageServiceTestIT {
             .append("Hydroid Hydrozoa Jellyfish Corals").append("\n")
             .toString();
 
-      Assert.assertEquals(expectedMetadata, metadata);
+      Assert.assertEquals(expectedMetadata, actualMetadata.toString());
    }
 
 }


### PR DESCRIPTION
- Created the object ImageMetadata to hold the response from ImageService.getImageMetadata()
- Adjusted calls to this service accordingly
- Added confidence score to the list of image labels, e.g. Invertebrate (0.82)