### PR TITLE
Generating image thumbnail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
             <version>2.2.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.imgscalr</groupId>
+            <artifactId>imgscalr-lib</artifactId>
+            <version>4.2</version>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/src/main/java/au/gov/ga/hydroid/service/S3Client.java
+++ b/src/main/java/au/gov/ga/hydroid/service/S3Client.java
@@ -14,6 +14,7 @@ public interface S3Client {
    public InputStream getFile(String bucketName, String key);
    public byte[] getFileAsByteArray(String bucketName, String key);
    public void storeFile(String bucketName, String key, String content, String contentType);
+   public void storeFile(String bucketName, String key, InputStream content, String contentType);
    public void deleteFile(String bucketName, String key);
    public List<S3ObjectSummary> listObjects(String bucketName, String key);
    public void copyObject(String sourceBucketName, String sourceKey, String destinationBucketName, String destinationKey);

--- a/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
@@ -126,7 +126,7 @@ public class EnhancerServiceImpl implements EnhancerService {
       rdfDocument.add(statement);
 
       // Added property:image to the RDF document
-      if (docType.equals(DocumentType.DOCUMENT.name())) {
+      if (docType.equals(DocumentType.IMAGE.name())) {
          property = ResourceFactory.createProperty("http://purl.org/dc/dcmitype/Image");
          object = ResourceFactory.createProperty(documentUrl.toString());
          statement = ResourceFactory.createStatement(subject, property, object);
@@ -207,10 +207,10 @@ public class EnhancerServiceImpl implements EnhancerService {
                              configuration.getS3EnhancerOutputImages() + urn + "_thumb",
                              byteArrayInputStream,
                              "image/png");
+                     properties.put("imgThumb",configuration.getS3OutputUrl() + "/images/" + urn + "_thumb");
                   } catch (Exception e) {
                      logger.error("Failed to resize image '" + title + "'.",e);
                   }
-
                }
 
                // Add enhanced document to Solr

--- a/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
@@ -15,12 +15,17 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.jena.rdf.model.*;
+import org.imgscalr.Scalr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.*;
 
@@ -174,28 +179,44 @@ public class EnhancerServiceImpl implements EnhancerService {
          if (rdfDocument != null) {
             // Generate dictionary with properties we are interested in
             properties = generateSolrDocument(rdfDocument, content, docType, title);
-
+            urn = properties.getProperty("about");
             // Content has been tagged with our vocabularies
             if (!properties.isEmpty()) {
 
-               // Add enhanced document to Solr
-               logger.info("enhance - about to add document to solr");
-               urn = properties.getProperty("about");
-               solrClient.addDocument(configuration.getSolrCollection(), properties);
-               logger.info("enhance - document added to solr");
-
                // Store full enhanced doc (rdf) in S3
                s3Client.storeFile(configuration.getS3OutputBucket(), configuration.getS3EnhancerOutput() + urn,
-                     enhancedText, ContentType.APPLICATION_XML.getMimeType());
+                       enhancedText, ContentType.APPLICATION_XML.getMimeType());
 
                // Also store original image in S3
                if (docType.equals(DocumentType.IMAGE.name())) {
                   logger.info("enhance - saving image in S3 and its metadata in the database");
                   s3Client.copyObject(configuration.getS3Bucket(), configuration.getS3EnhancerInput() + "images/" + title,
-                        configuration.getS3OutputBucket(), configuration.getS3EnhancerOutputImages() + urn);
+                          configuration.getS3OutputBucket(), configuration.getS3EnhancerOutputImages() + urn);
                   saveOrUpdateImageMetadata(origin, content);
                   logger.info("enhance - original image content and metadata saved");
+                  InputStream origImage = s3Client.getFile(configuration.getS3Bucket(), configuration.getS3EnhancerInput() + "images/" + title);
+                  BufferedImage image = ImageIO.read(origImage);
+
+                  try {
+                     BufferedImage resized = Scalr.resize(image,200);
+                     ByteArrayOutputStream os = new ByteArrayOutputStream();
+                     ImageIO.write(resized,"png", os);
+                     InputStream byteArrayInputStream = new ByteArrayInputStream(os.toByteArray());
+                     s3Client.storeFile(
+                             configuration.getS3OutputBucket(),
+                             configuration.getS3EnhancerOutputImages() + urn + "_thumb",
+                             byteArrayInputStream,
+                             "image/png");
+                  } catch (Exception e) {
+                     logger.error("Failed to resize image '" + title + "'.",e);
+                  }
+
                }
+
+               // Add enhanced document to Solr
+               logger.info("enhance - about to add document to solr");
+               solrClient.addDocument(configuration.getSolrCollection(), properties);
+               logger.info("enhance - document added to solr");
 
                // Store full document in DB
                logger.info("enhance - saving document in the database");

--- a/src/main/java/au/gov/ga/hydroid/service/impl/S3ClientImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/S3ClientImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -71,6 +72,12 @@ public class S3ClientImpl implements S3Client {
 
    @Override
    public void storeFile(String bucketName, String key, String content, String contentType) {
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes());
+      storeFile(bucketName,key,inputStream,contentType);
+   }
+
+   @Override
+   public void storeFile(String bucketName, String key, InputStream content, String contentType) {
       AmazonS3 s3 = getAmazonS3();
 
       // If the bucket doesn't exist we create it
@@ -78,13 +85,12 @@ public class S3ClientImpl implements S3Client {
          s3.createBucket(bucketName, "ap-southeast-2");
       }
 
-      InputStream fileContent = new ByteArrayInputStream(content.getBytes());
       ObjectMetadata metadata = new ObjectMetadata();
       if (contentType != null) {
          metadata.setContentType(contentType);
       }
 
-      s3.putObject(bucketName, key, fileContent, metadata);
+      s3.putObject(bucketName, key, content, metadata);
    }
 
    @Override

--- a/src/test/java/au/gov/ga/hydroid/mock/CustomMockS3Client.java
+++ b/src/test/java/au/gov/ga/hydroid/mock/CustomMockS3Client.java
@@ -33,6 +33,11 @@ public class CustomMockS3Client implements S3Client {
    }
 
    @Override
+   public void storeFile(String bucketName, String key, InputStream content, String contentType) {
+
+   }
+
+   @Override
    public void deleteFile(String bucketName, String key) {
 
    }


### PR DESCRIPTION
Generating image thumbnail (approx 200x200, keep aspect ratio) and adding the result to Solr image as "imgThumb". This will avoid issue with possible giant images being displayed in the hydroid-client. 

Possible issue is around memory consumption, original image pulled into memory for resize, logged error and broken thumbnails should be pretty obvious. Will add large images in S3 (currently 15mb is the biggest) to see what kind of limit there will be with our current AWS instances.

@scelton could you give this a sanity check?