### PR TITLE
Modify POM to create both JAR and WAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>au.gov.ga</groupId>
     <artifactId>hydroid</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -233,6 +233,22 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <jarName>hydroid</jarName>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 


### PR DESCRIPTION
Non-breaking change to POM (IE won't effect current deployment setup).

Just creates a WAR side by side with existing JAR being generated.

@scelton could you have a quick check?