### PR TITLE
Hydroid chain and new enhancement status

### DIFF
--- a/config/org.apache.stanbol.enhancer.chain.weighted.impl.WeightedChain-hydroid.config
+++ b/config/org.apache.stanbol.enhancer.chain.weighted.impl.WeightedChain-hydroid.config
@@ -1,3 +1,3 @@
 stanbol.enhancer.chain.name="hydroid"
-stanbol.enhancer.chain.weighted.chain=["tika;optional","langdetect","opennlp-sentence","opennlp-token","opennlp-pos","opennlp-chunker","GALinking"]
+stanbol.enhancer.chain.weighted.chain=["tika;optional","langdetect","opennlp-sentence","opennlp-token","GALinking"]
 service.ranking=I"0"

--- a/src/main/java/au/gov/ga/hydroid/model/EnhancementStatus.java
+++ b/src/main/java/au/gov/ga/hydroid/model/EnhancementStatus.java
@@ -5,6 +5,6 @@ package au.gov.ga.hydroid.model;
  */
 public enum EnhancementStatus {
 
-   SUCCESS, FAILURE, PENDING;
+   SUCCESS, FAILURE, PENDING, SKIP;
 
 }


### PR DESCRIPTION
- Removed opennlp-pos and opennlp-chunker from the Hydroid Chain as they were causing issues with singular/plural (mainly for images).
- New status SKIP. Documents with status SKIP will not be picked up next time the enhancer kicks in.