### PR TITLE
Prevent Duplicates

### DIFF
--- a/src/main/java/au/gov/ga/hydroid/dto/DocumentDTO.java
+++ b/src/main/java/au/gov/ga/hydroid/dto/DocumentDTO.java
@@ -15,6 +15,7 @@ public class DocumentDTO {
    private String origin;
    private String author;
    private Date dateCreated;
+   private String sha1Hash;
 
    public String getTitle() {
       return title;
@@ -62,6 +63,14 @@ public class DocumentDTO {
 
    public void setDateCreated(Date dateCreated) {
       this.dateCreated = dateCreated;
+   }
+
+   public String getSha1Hash() {
+      return sha1Hash;
+   }
+
+   public void setSha1Hash(String sha1Hash) {
+      this.sha1Hash = sha1Hash;
    }
 
 }

--- a/src/main/java/au/gov/ga/hydroid/model/Document.java
+++ b/src/main/java/au/gov/ga/hydroid/model/Document.java
@@ -17,6 +17,7 @@ public class Document {
    private String statusReason;
    private Date processDate;
    private String parserName;
+   private String sha1Hash;
 
    public long getId() {
       return id;
@@ -88,6 +89,14 @@ public class Document {
 
    public void setParserName(String parserName) {
       this.parserName = parserName;
+   }
+
+   public String getSha1Hash() {
+      return sha1Hash;
+   }
+
+   public void setSha1Hash(String sha1Hash) {
+      this.sha1Hash = sha1Hash;
    }
 
 }

--- a/src/main/java/au/gov/ga/hydroid/model/DocumentRowMapper.java
+++ b/src/main/java/au/gov/ga/hydroid/model/DocumentRowMapper.java
@@ -31,6 +31,7 @@ public class DocumentRowMapper implements RowMapper {
          document.setStatusReason(resultSet.getString("status_reason"));
          document.setProcessDate(resultSet.getTimestamp("process_date"));
          document.setParserName(resultSet.getString("parser_name"));
+         document.setSha1Hash(resultSet.getString("sha1_hash"));
       } catch (SQLException e) {
          throw new HydroidException(e);
       }

--- a/src/main/java/au/gov/ga/hydroid/model/EnhancementStatus.java
+++ b/src/main/java/au/gov/ga/hydroid/model/EnhancementStatus.java
@@ -5,6 +5,6 @@ package au.gov.ga.hydroid.model;
  */
 public enum EnhancementStatus {
 
-   SUCCESS, FAILURE, PENDING, SKIP;
+   SUCCESS, FAILURE, PENDING, SKIP, DUPLICATE;
 
 }

--- a/src/main/java/au/gov/ga/hydroid/service/DocumentService.java
+++ b/src/main/java/au/gov/ga/hydroid/service/DocumentService.java
@@ -13,6 +13,7 @@ public interface DocumentService {
    List<Document> findAll();
    Document findByUrn(String urn);
    Document findByOrigin(String origin);
+   Document findBySha1Hash(String sha1Hash);
    List<Document> findByStatus(EnhancementStatus status);
    void create(Document document);
    void deleteByUrn(String urn);

--- a/src/main/java/au/gov/ga/hydroid/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/DocumentServiceImpl.java
@@ -64,17 +64,30 @@ public class DocumentServiceImpl implements DocumentService {
    }
 
    @Override
+   public Document findBySha1Hash(String sha1Hash) {
+      try {
+         return (Document) jdbcTemplate.queryForObject("SELECT * FROM documents where sha1_hash = ?",
+               new String[]{sha1Hash}, new DocumentRowMapper());
+      } catch (IncorrectResultSizeDataAccessException e) {
+         logger.debug("findBySha1Hash - IncorrectResultSizeDataAccessException: ", e);
+         return null;
+      }
+   }
+
+   @Override
    public List<Document> findByStatus(EnhancementStatus status) {
-      return jdbcTemplate.query("SELECT * FROM documents where status = ?", new String[]{status.name()}, new DocumentRowMapper());
+      return jdbcTemplate.query("SELECT * FROM documents where status = ?", new String[]{status.name()},
+            new DocumentRowMapper());
    }
 
    @Override
    public void create(Document document) {
       try {
          String sql = "insert into documents (origin, urn, title, type, status, "
-               + "status_reason, process_date, parser_name) values (?, ?, ?, ?, ?, ?, ?, ?)";
-         jdbcTemplate.update(sql, document.getOrigin(), document.getUrn(), document.getTitle(), document.getType().name(),
-               document.getStatus().name(), document.getStatusReason(), getUTCDateTime(), document.getParserName());
+               + "status_reason, process_date, parser_name, sha1_hash) values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+         jdbcTemplate.update(sql, document.getOrigin(), document.getUrn(), document.getTitle(),
+               document.getType().name(), document.getStatus().name(), document.getStatusReason(), getUTCDateTime(),
+               document.getParserName(), document.getSha1Hash());
       } catch (DataAccessException e) {
          throw new HydroidException(e.getMostSpecificCause());
       }
@@ -88,9 +101,10 @@ public class DocumentServiceImpl implements DocumentService {
    @Override
    public void update(Document document) {
       try {
-         String sql = "update documents set title = ?, urn = ?, status = ?, status_reason = ?, process_date = ? where id = ?";
+         String sql = "update documents set title = ?, urn = ?, status = ?, status_reason = ?, process_date = ?," +
+               "sha1_hash = ? where id = ?";
          jdbcTemplate.update(sql, document.getTitle(), document.getUrn(), document.getStatus().name(),
-               document.getStatusReason(), getUTCDateTime(), document.getId());
+               document.getStatusReason(), getUTCDateTime(), document.getSha1Hash(), document.getId());
       } catch (DataAccessException e) {
          throw new HydroidException(e.getMostSpecificCause());
       }

--- a/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
@@ -234,8 +234,9 @@ public class EnhancerServiceImpl implements EnhancerService {
          // Document was not enhanced or previous enhancement failed
          if (document == null) {
             String newOrigin = configuration.getS3Bucket() + ":" + object.getKey();
-            byte[] s3FileContent = s3Client.getFileAsByteArray(object.getBucketName(), object.getKey());
-            document = documentService.findBySha1Hash(new String(s3FileContent));
+            InputStream s3FileContent = s3Client.getFile(object.getBucketName(), object.getKey());
+            String sha1Hash = IOUtils.getSha1Hash(s3FileContent);
+            document = documentService.findBySha1Hash(sha1Hash);
             if (document == null) {
                output.add(object);
 
@@ -284,8 +285,8 @@ public class EnhancerServiceImpl implements EnhancerService {
 
             metadata = new Metadata();
             document.setContent(IOUtils.parseStream(s3FileContent, metadata));
-            document.setSha1Hash(IOUtils.getSha1Hash(s3FileContent));
             document.setOrigin(configuration.getS3Bucket() + ":" + object.getKey());
+            document.setSha1Hash(IOUtils.getSha1Hash(s3FileContent));
             copyMetadataToDocument(metadata, document, getFileNameFromS3ObjectSummary(object));
 
             enhance(document);

--- a/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/EnhancerServiceImpl.java
@@ -30,6 +30,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,6 +107,19 @@ public class EnhancerServiceImpl implements EnhancerService {
       }
    }
 
+   private void saveImageDetails(String urn, DocumentDTO document, Properties properties) throws IOException {
+      logger.info("saveImageDetails - saving image in S3 and its metadata in the database");
+      int bucketEndPosition = document.getOrigin().indexOf(":") + 1;
+      s3Client.copyObject(configuration.getS3Bucket(), document.getOrigin().substring(bucketEndPosition),
+            configuration.getS3OutputBucket(), configuration.getS3EnhancerOutputImages() + urn);
+      saveOrUpdateImageMetadata(document.getOrigin(), document.getContent());
+      logger.info("saveImageDetails - original image content and metadata saved");
+      InputStream origImage = s3Client.getFile(configuration.getS3Bucket(),
+            document.getOrigin().substring(bucketEndPosition));
+      BufferedImage image = ImageIO.read(origImage);
+      properties.put("imgThumb", getImageThumb(image, urn));
+   }
+
    @Override
    public boolean enhance(DocumentDTO document) {
 
@@ -115,7 +129,8 @@ public class EnhancerServiceImpl implements EnhancerService {
 
          // Send content to Stanbol for enhancement
          logger.info("enhance - about to post to stanbol server");
-         String enhancedText = stanbolClient.enhance(configuration.getStanbolChain(), document.getContent(), StanbolMediaTypes.RDFXML);
+         String enhancedText = stanbolClient.enhance(configuration.getStanbolChain(), document.getContent(),
+               StanbolMediaTypes.RDFXML);
          logger.info("enhance - received results from stanbol server");
          enhancedText = StringUtils.replace(enhancedText, ":content-item-sha1-", ":content-item-sha1:");
          logger.info("enhance - changed urn pattern, still contain old: " + enhancedText.contains(":content-item-sha1-"));
@@ -143,15 +158,7 @@ public class EnhancerServiceImpl implements EnhancerService {
 
          // Also store original image in S3
          if (document.getDocType().equals(DocumentType.IMAGE.name())) {
-            logger.info("enhance - saving image in S3 and its metadata in the database");
-            int bucketEndPosition = document.getOrigin().indexOf(":") + 1;
-            s3Client.copyObject(configuration.getS3Bucket(), document.getOrigin().substring(bucketEndPosition),
-                    configuration.getS3OutputBucket(), configuration.getS3EnhancerOutputImages() + urn);
-            saveOrUpdateImageMetadata(document.getOrigin(), document.getContent());
-            logger.info("enhance - original image content and metadata saved");
-            InputStream origImage = s3Client.getFile(configuration.getS3Bucket(), document.getOrigin().substring(bucketEndPosition));
-            BufferedImage image = ImageIO.read(origImage);
-            properties.put("imgThumb", getImageThumb(image, urn));
+            saveImageDetails(urn, document, properties);
          }
 
          // Add enhanced document to Solr
@@ -194,6 +201,7 @@ public class EnhancerServiceImpl implements EnhancerService {
       document.setType(DocumentType.valueOf(documentDTO.getDocType()));
       document.setStatus(status);
       document.setStatusReason(statusReason);
+      document.setSha1Hash(documentDTO.getSha1Hash());
       if (document.getId() == 0) {
          documentService.create(document);
       } else {
@@ -224,7 +232,24 @@ public class EnhancerServiceImpl implements EnhancerService {
          origin = object.getBucketName() + ":" + object.getKey();
          document = documentService.findByOrigin(origin);
          // Document was not enhanced or previous enhancement failed
-         if (document == null || document.getStatus() == EnhancementStatus.FAILURE) {
+         if (document == null) {
+            String newOrigin = configuration.getS3Bucket() + ":" + object.getKey();
+            byte[] s3FileContent = s3Client.getFileAsByteArray(object.getBucketName(), object.getKey());
+            document = documentService.findBySha1Hash(new String(s3FileContent));
+            if (document == null) {
+               output.add(object);
+
+            // Same document found at a different source location skip and set status as duplicate
+            } else if (!document.getOrigin().equals(newOrigin)) {
+               Document duplicate = new Document();
+               duplicate.setOrigin(newOrigin);
+               duplicate.setTitle(document.getTitle());
+               duplicate.setType(document.getType());
+               duplicate.setStatus(EnhancementStatus.DUPLICATE);
+               duplicate.setStatusReason("Document already exists at " + origin);
+               documentService.create(duplicate);
+            }
+         } else if (document.getStatus() == EnhancementStatus.FAILURE) {
             output.add(object);
          }
       }
@@ -259,6 +284,7 @@ public class EnhancerServiceImpl implements EnhancerService {
 
             metadata = new Metadata();
             document.setContent(IOUtils.parseStream(s3FileContent, metadata));
+            document.setSha1Hash(IOUtils.getSha1Hash(s3FileContent));
             document.setOrigin(configuration.getS3Bucket() + ":" + object.getKey());
             copyMetadataToDocument(metadata, document, getFileNameFromS3ObjectSummary(object));
 
@@ -302,6 +328,7 @@ public class EnhancerServiceImpl implements EnhancerService {
             }
 
             document.setOrigin(dbDocument.getOrigin());
+            document.setSha1Hash(IOUtils.getSha1Hash(inputStream));
             copyMetadataToDocument(metadata, document, dbDocument.getOrigin());
 
             enhance(document);
@@ -355,6 +382,7 @@ public class EnhancerServiceImpl implements EnhancerService {
             if (document.getContent() == null) {
                s3FileContent = s3Client.getFile(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey());
                document.setContent("The labels found for " + document.getTitle() + " are " + getImageMetadataAsString(s3FileContent));
+               document.setSha1Hash(IOUtils.getSha1Hash(s3FileContent));
             }
 
             enhance(document);

--- a/src/main/java/au/gov/ga/hydroid/utils/IOUtils.java
+++ b/src/main/java/au/gov/ga/hydroid/utils/IOUtils.java
@@ -1,5 +1,7 @@
 package au.gov.ga.hydroid.utils;
 
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
@@ -77,6 +79,16 @@ public class IOUtils {
          throw new HydroidException(e);
       }
       return null;
+   }
+
+   public static String getSha1Hash(InputStream inputStream) {
+      try {
+         byte[] input = fromInputStreamToByteArray(inputStream);
+         byte[] output = DigestUtils.getSha1Digest().digest(input);
+         return Hex.encodeHexString(output);
+      } catch (Exception e) {
+         throw new HydroidException(e);
+      }
    }
 
 }

--- a/src/main/scripts/create-schema.sql
+++ b/src/main/scripts/create-schema.sql
@@ -9,7 +9,8 @@ CREATE TABLE hydroid.documents (
     status varchar(20) NOT NULL,
     status_reason varchar(1000) NULL,
     process_date timestamp NOT NULL,
-    parser_name varchar(50) NULL
+    parser_name varchar(50) NULL,
+    sha1_hash varchar(100) NULL
 );
 
 CREATE UNIQUE INDEX documents_urn_idx ON hydroid.documents (urn);

--- a/src/main/scripts/create-schema.sql
+++ b/src/main/scripts/create-schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE hydroid.documents (
 
 CREATE UNIQUE INDEX documents_urn_idx ON hydroid.documents (urn);
 CREATE UNIQUE INDEX documents_origin_idx ON hydroid.documents (origin);
+CREATE UNIQUE INDEX documents_sha1hash_idx ON hydroid.documents (sha1_hash);
 CREATE INDEX documents_status_idx ON hydroid.documents (status);
 
 CREATE TABLE hydroid.image_metadata (

--- a/src/test/java/au/gov/ga/hydroid/mock/CustomMockDocumentService.java
+++ b/src/test/java/au/gov/ga/hydroid/mock/CustomMockDocumentService.java
@@ -40,6 +40,11 @@ public class CustomMockDocumentService implements DocumentService {
    }
 
    @Override
+   public Document findBySha1Hash(String sha1Hash) {
+      return null;
+   }
+
+   @Override
    public List<Document> findByStatus(EnhancementStatus status) {
       return null;
    }

--- a/src/test/java/au/gov/ga/hydroid/service/DocumentServiceTest.java
+++ b/src/test/java/au/gov/ga/hydroid/service/DocumentServiceTest.java
@@ -53,7 +53,7 @@ public class DocumentServiceTest {
          documentService.create(document);
       } catch (HydroidException e) {
          Assert.assertEquals("Unique index or primary key violation: \"DOCUMENTS_ORIGIN_IDX ON PUBLIC.DOCUMENTS(ORIGIN) VALUES ('origin:test1', 1)\"; SQL statement:\n" +
-               "insert into documents (origin, urn, title, type, status, status_reason, process_date, parser_name) values (?, ?, ?, ?, ?, ?, ?, ?) [23505-191]",
+               "insert into documents (origin, urn, title, type, status, status_reason, process_date, parser_name, sha1_hash) values (?, ?, ?, ?, ?, ?, ?, ?, ?) [23505-191]",
                e.getMessage());
       }
    }
@@ -75,6 +75,13 @@ public class DocumentServiceTest {
    @Test
    public void testFindByOrigin() {
       Document document = documentService.findByOrigin("origin:test1");
+      Assert.assertNotNull(document);
+      Assert.assertEquals("origin:test1", document.getOrigin());
+   }
+
+   @Test
+   public void testFindBySha1Hash() {
+      Document document = documentService.findBySha1Hash("d751cdfbf49e8ea17afd9cdca03f06f87ce37277");
       Assert.assertNotNull(document);
       Assert.assertEquals("origin:test1", document.getOrigin());
    }

--- a/src/test/java/au/gov/ga/hydroid/utils/IOUtilsTest.java
+++ b/src/test/java/au/gov/ga/hydroid/utils/IOUtilsTest.java
@@ -86,4 +86,12 @@ public class IOUtilsTest {
       }
    }
 
+   @Test
+   public void testGetSha1Hash() {
+      String documentPath = "/testfiles/36_4_1175-1197_Buss_and_Clote.pdf";
+      String sha1Hash = IOUtils.getSha1Hash(this.getClass().getResourceAsStream(documentPath));
+      Assert.assertNotNull("SHA1 is null: ", sha1Hash);
+      Assert.assertEquals("SHA1 is not equal: ", "b5d5b085d117cbb2625c6177b3617cbfcdeaaaf7", sha1Hash);
+   }
+
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,5 +1,5 @@
-insert into documents values (null, 'origin:test1', 'urn:test1', 'Title for (urn:test1)', 'DOCUMENT', 'SUCCESS', null, now(), null);
-insert into documents values (null, 'origin:delete', 'urn:delete', 'Title for (urn:delete)', 'DOCUMENT', 'PENDING', null, now(), null);
+insert into documents values (null, 'origin:test1', 'urn:test1', 'Title for (urn:test1)', 'DOCUMENT', 'SUCCESS', null, now(), null, 'd751cdfbf49e8ea17afd9cdca03f06f87ce37277');
+insert into documents values (null, 'origin:delete', 'urn:delete', 'Title for (urn:delete)', 'DOCUMENT', 'PENDING', null, now(), null, 'edab181efcb958c9612c9478997ef748da8def97');
 
 insert into image_metadata values ('origin:whale', 'Whale, Mammal, Fish');
 insert into image_metadata values ('origin:monkey', 'Animal, Mammal, Primate');

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -8,7 +8,8 @@ CREATE TABLE documents (
     status varchar(20) NOT NULL,
     status_reason varchar(1000) NULL,
     process_date timestamp NOT NULL,
-    parser_name varchar(50) NULL
+    parser_name varchar(50) NULL,
+    sha1_hash varchar(100) NULL
 );
 
 CREATE UNIQUE INDEX documents_urn_idx ON documents (urn);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -14,6 +14,8 @@ CREATE TABLE documents (
 
 CREATE UNIQUE INDEX documents_urn_idx ON documents (urn);
 CREATE UNIQUE INDEX documents_origin_idx ON documents (origin);
+CREATE UNIQUE INDEX documents_sha1hash_idx ON documents (sha1_hash);
+CREATE INDEX documents_status_idx ON documents (status);
 
 DROP TABLE IF EXISTS image_metadata;
 CREATE TABLE image_metadata (


### PR DESCRIPTION
- New column in the documents table to store a sha1_hash of the document content
- Create SHA1 of document content at the start of enhancement process
- Skip and set status as DUPLICATE when the same content (sha1_hash) is found at a different location (origin)
- DB changes and tests