### PR TITLE
Small fix to include nodeType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/test/resources/testfiles/hydroid-output
 google-vision.json
 
 local-application.properties
+src/main/resources/local.properties

--- a/src/main/java/au/gov/ga/hydroid/controller/MenuController.java
+++ b/src/main/java/au/gov/ga/hydroid/controller/MenuController.java
@@ -36,12 +36,15 @@ public class MenuController {
 
          while (resources.hasNext()) {
             final Resource parentRes = resources.nextResource();
+            if(!parentRes.getProperty(RDF.type).getObject().toString().equals(SKOS.ConceptScheme.toString()))
+               continue;
 
             if (parentRes.hasProperty(RDFS.label)) {
                Statement resStmt = parentRes.getProperty(RDFS.label);
                menuItem = new MenuDTO();
                menuItem.setNodeLabel(resStmt.getString());
                menuItem.setNodeURI(resStmt.getSubject().getURI());
+               menuItem.setNodeType(null);
                ResIterator childResources = model.listResourcesWithProperty(SKOS.topConceptOf);
 
                while (childResources.hasNext()) {
@@ -54,6 +57,7 @@ public class MenuController {
                      childMenuItem = new MenuDTO();
                      childMenuItem.setNodeLabel(childResStmt.getString());
                      childMenuItem.setNodeURI(childResStmt.getSubject().getURI());
+                     childMenuItem.setNodeType(SKOS.Concept.toString());
 
                      appendNarrowerChildren(model,childRes,childMenuItem);
                      menuItem.getChildren().add(childMenuItem);
@@ -83,6 +87,7 @@ public class MenuController {
                broaderItem = new MenuDTO();
                broaderItem.setNodeURI(broaderURI);
                broaderItem.setNodeLabel(broaderStmt.getString());
+               broaderItem.setNodeType(SKOS.Concept.toString());
 
               appendNarrowerChildren(model,broaderRes,broaderItem);
                items.add(broaderItem);

--- a/src/main/java/au/gov/ga/hydroid/dto/MenuDTO.java
+++ b/src/main/java/au/gov/ga/hydroid/dto/MenuDTO.java
@@ -8,9 +8,10 @@ import java.util.TreeSet;
  */
 public class MenuDTO implements Comparable {
 
-    private String nodeURI;
-    private String nodeLabel;
-    private SortedSet<MenuDTO> children;
+   private String nodeURI;
+   private String nodeLabel;
+   private SortedSet<MenuDTO> children;
+   private String nodeType;
 
    public String getNodeURI() {
       return nodeURI;
@@ -32,6 +33,14 @@ public class MenuDTO implements Comparable {
       return children;
    }
 
+   public String getNodeType() {
+      return nodeType;
+   }
+
+   public void setNodeType(String nodeType) {
+      this.nodeType = nodeType;
+   }
+
    public MenuDTO() {
       children = new TreeSet<>();
    }
@@ -42,5 +51,4 @@ public class MenuDTO implements Comparable {
       MenuDTO menuDTO = (MenuDTO) o;
       return getNodeLabel().compareTo(menuDTO.getNodeLabel());
    }
-
 }


### PR DESCRIPTION
Client uses node type to distinguish between root menus and other menus.
This just adds the concept back in to the result from the server.

Without it, menus currently look like:

![image](https://cloud.githubusercontent.com/assets/234642/15174265/1555f290-17a4-11e6-8431-70a86e73014c.png)

Fixes it back to:

![image](https://cloud.githubusercontent.com/assets/234642/15174288/3148b604-17a4-11e6-923d-ea23cdaf5ed8.png)
