### PR TITLE
Get S3 object metadata for validation

### DIFF
--- a/src/main/java/au/gov/ga/hydroid/dto/FileMetadata.java
+++ b/src/main/java/au/gov/ga/hydroid/dto/FileMetadata.java
@@ -1,0 +1,15 @@
+package au.gov.ga.hydroid.dto;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+/**
+ * Created by u24529 on 24/05/2016.
+ */
+public class FileMetadata extends ObjectMetadata {
+
+   @Override
+   public long getInstanceLength() {
+      return getContentLength();
+   }
+
+}

--- a/src/main/java/au/gov/ga/hydroid/service/S3Client.java
+++ b/src/main/java/au/gov/ga/hydroid/service/S3Client.java
@@ -1,5 +1,7 @@
 package au.gov.ga.hydroid.service;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
 import java.io.InputStream;
 import java.util.List;
 
@@ -7,6 +9,7 @@ import java.util.List;
  * Created by u24529 on 8/02/2016.
  */
 public interface S3Client {
+
    String getAccountOwner();
 
    InputStream getFile(String bucketName, String key);
@@ -15,11 +18,14 @@ public interface S3Client {
 
    void storeFile(String bucketName, String key, String content, String contentType);
 
-   void storeFile(String bucketName, String key, InputStream content, String contentType);
+   void storeFile(String bucketName, String key, InputStream content, String contentType, long contentLength);
 
    void deleteFile(String bucketName, String key);
 
    List<DataObjectSummary> listObjects(String bucketName, String key);
 
    void copyObject(String sourceBucketName, String sourceKey, String destinationBucketName, String destinationKey);
+
+   ObjectMetadata getObjectMetadata(String bucketName, String key);
+
 }

--- a/src/main/java/au/gov/ga/hydroid/service/impl/FileSystemClientImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/FileSystemClientImpl.java
@@ -13,12 +13,10 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service("s3FileSystem")
@@ -96,7 +94,7 @@ public class FileSystemClientImpl implements S3Client {
    public void storeFile(String bucketName, String key, String content, String contentType) {
       try {
          ensureDirectoriesExist(bucketName, key);
-         Files.write(doGetFile(bucketName, key).toPath(), Collections.singletonList(content), Charset.forName("UTF-8"));
+         Files.write(doGetFile(bucketName, key).toPath(), content.getBytes());
       } catch (IOException e) {
          logger.debug("storeFile - IOException: ", e);
       }

--- a/src/main/java/au/gov/ga/hydroid/service/impl/FileSystemClientImpl.java
+++ b/src/main/java/au/gov/ga/hydroid/service/impl/FileSystemClientImpl.java
@@ -1,7 +1,9 @@
 package au.gov.ga.hydroid.service.impl;
 
+import au.gov.ga.hydroid.dto.FileMetadata;
 import au.gov.ga.hydroid.service.DataObjectSummary;
 import au.gov.ga.hydroid.service.S3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -101,7 +103,7 @@ public class FileSystemClientImpl implements S3Client {
    }
 
    @Override
-   public void storeFile(String bucketName, String key, InputStream content, String contentType) {
+   public void storeFile(String bucketName, String key, InputStream content, String contentType, long contentLength) {
       try {
          ensureDirectoriesExist(bucketName, key);
          Files.write(doGetFile(bucketName, key).toPath(), IOUtils.toByteArray(content));
@@ -145,6 +147,17 @@ public class FileSystemClientImpl implements S3Client {
       } catch (IOException e) {
          logger.debug("copyObject - IOException: ", e);
       }
+   }
+
+   @Override
+   public ObjectMetadata getObjectMetadata(String bucketName, String key) {
+      ObjectMetadata objectMetadata = new FileMetadata();
+      Path file = doGetFile(bucketName, key).toPath();
+      if (Files.exists(file)) {
+         long length = file.toFile().length();
+         objectMetadata.setContentLength(length);
+      }
+      return objectMetadata;
    }
 
 }

--- a/src/test/java/au/gov/ga/hydroid/integration/S3ClientTestIT.java
+++ b/src/test/java/au/gov/ga/hydroid/integration/S3ClientTestIT.java
@@ -3,6 +3,7 @@ package au.gov.ga.hydroid.integration;
 import au.gov.ga.hydroid.HydroidApplication;
 import au.gov.ga.hydroid.service.DataObjectSummary;
 import au.gov.ga.hydroid.service.S3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.apache.http.entity.ContentType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -70,6 +71,14 @@ public class S3ClientTestIT {
             break;
          }
       }
+   }
+
+   @Test
+   public void testObjectMetadata() {
+      ObjectMetadata objectMetadata = s3Client.getObjectMetadata("hydroid", "enhancer/input/documents/Ecological_Informatics_6_205.pdf");
+      Assert.assertNotNull(objectMetadata);
+      Assert.assertEquals(1324326, objectMetadata.getContentLength());
+      Assert.assertEquals(1324326, objectMetadata.getInstanceLength());
    }
 
 }

--- a/src/test/java/au/gov/ga/hydroid/mock/CustomMockS3Client.java
+++ b/src/test/java/au/gov/ga/hydroid/mock/CustomMockS3Client.java
@@ -3,6 +3,7 @@ package au.gov.ga.hydroid.mock;
 import au.gov.ga.hydroid.service.DataObjectSummary;
 import au.gov.ga.hydroid.service.S3Client;
 import au.gov.ga.hydroid.service.impl.DataObjectSummaryImpl;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import java.io.ByteArrayInputStream;
@@ -36,7 +37,7 @@ public class CustomMockS3Client implements S3Client {
    }
 
    @Override
-   public void storeFile(String bucketName, String key, InputStream content, String contentType) {
+   public void storeFile(String bucketName, String key, InputStream content, String contentType, long contentLength) {
 
    }
 
@@ -58,6 +59,11 @@ public class CustomMockS3Client implements S3Client {
    @Override
    public void copyObject(String sourceBucketName, String sourceKey, String destinationBucketName, String destinationKey) {
 
+   }
+
+   @Override
+   public ObjectMetadata getObjectMetadata(String bucketName, String key) {
+      return null;
    }
 
 }

--- a/src/test/java/au/gov/ga/hydroid/service/FileSystemClientImplTest.java
+++ b/src/test/java/au/gov/ga/hydroid/service/FileSystemClientImplTest.java
@@ -112,8 +112,8 @@ public class FileSystemClientImplTest {
       fsClient.storeFile("test", "test.txt", "Hello", "text/plain");
       ObjectMetadata objectMetadata = fsClient.getObjectMetadata("test", "test.txt");
       Assert.assertNotNull(objectMetadata);
-      Assert.assertEquals(7, objectMetadata.getContentLength());
-      Assert.assertEquals(7, objectMetadata.getInstanceLength());
+      Assert.assertEquals(5, objectMetadata.getContentLength());
+      Assert.assertEquals(5, objectMetadata.getInstanceLength());
    }
 
 }

--- a/src/test/java/au/gov/ga/hydroid/service/FileSystemClientImplTest.java
+++ b/src/test/java/au/gov/ga/hydroid/service/FileSystemClientImplTest.java
@@ -3,6 +3,7 @@ package au.gov.ga.hydroid.service;
 import au.gov.ga.hydroid.service.impl.DataObjectSummaryImpl;
 import au.gov.ga.hydroid.service.impl.FileSystemClientImpl;
 import au.gov.ga.hydroid.utils.IOUtils;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class FileSystemClientImplTest {
    @Test
    public void testStoreFileFromStream() throws Exception {
       InputStream fileContent = new ByteArrayInputStream("Hello".getBytes());
-      fsClient.storeFile("test", "test.txt", fileContent, "text/plain");
+      fsClient.storeFile("test", "test.txt", fileContent, "text/plain", 5);
       InputStream is = fsClient.getFile("test", "test.txt");
       String result = IOUtils.parseStream(is);
       Assert.assertEquals("Hello", result.trim());
@@ -104,6 +105,15 @@ public class FileSystemClientImplTest {
       Assert.assertEquals("test", object.getBucketName());
       Assert.assertEquals("/foo/test.txt", object.getKey());
       Assert.assertNotNull(fsClient.getFile(object.getBucketName(), object.getKey()));
+   }
+
+   @Test
+   public void testGetObjectMetadata() throws Exception {
+      fsClient.storeFile("test", "test.txt", "Hello", "text/plain");
+      ObjectMetadata objectMetadata = fsClient.getObjectMetadata("test", "test.txt");
+      Assert.assertNotNull(objectMetadata);
+      Assert.assertEquals(7, objectMetadata.getContentLength());
+      Assert.assertEquals(7, objectMetadata.getInstanceLength());
    }
 
 }


### PR DESCRIPTION
- Get object metadata and check if files exceed the max size of 50MB before streaming and sending content for enhancement.
- Set contentLength before s3.putObject